### PR TITLE
error for vcovHC(..., component = 'stage1')

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ivreg
 Title: Instrumental-Variables Regression by '2SLS', '2SM', or '2SMM', with Diagnostics
 Version: 0.6-6
-Date: 2025-09-09
+Date: 2026-02-09
 Authors@R: c(person(given = "John", family = "Fox", role = "aut", email = "jfox@mcmaster.ca", comment = c(ORCID = "0000-0002-1196-8012")),
              person(given = "Christian", family = "Kleiber", role = "aut", email = "Christian.Kleiber@unibas.ch", comment = c(ORCID = "0000-0002-6781-4733")),
              person(given = "Achim", family = "Zeileis", role = c("aut", "cre"), email = "Achim.Zeileis@R-project.org", comment = c(ORCID = "0000-0003-0918-3766")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,10 @@
 * The `summary()` method now also works correctly if there are aliased
   coefficients that are `NA` (reported by Alex Hayes in #24).
 
+* An error is issued now if `vcovHC(..., component = "stage1")` is requested
+  because currently only `"stage2"` (the default) is supported (reported in #26
+  by Matthew Bhagat-Conway).
+
 
 # Version 0.6-5
 

--- a/R/ivregMethods.R
+++ b/R/ivregMethods.R
@@ -115,7 +115,9 @@ estfun.ivreg <- function (x, ...)
 
 #' @rdname ivregMethods
 #' @exportS3Method sandwich::vcovHC
-vcovHC.ivreg <- function (x, ...) {
+vcovHC.ivreg <- function (x, component = "stage2", ...) {
+    component <- match.arg(component, c("stage2", "stage1"))
+    if(component == "stage1") stop("vcovHC() is not yet implemented for stage1 component")
     class(x) <- c("ivreg_projected", "ivreg")
     sandwich::vcovHC.default(x, ...)
 }

--- a/man/ivregMethods.Rd
+++ b/man/ivregMethods.Rd
@@ -30,7 +30,7 @@
 
 \method{estfun}{ivreg}(x, ...)
 
-\method{vcovHC}{ivreg}(x, ...)
+\method{vcovHC}{ivreg}(x, component = "stage2", ...)
 
 \method{terms}{ivreg}(x, component = c("regressors", "instruments", "full"), ...)
 


### PR DESCRIPTION
Fixes #26 

An error is issued now if `vcovHC(..., component = "stage1")` is requested because currently only `"stage2"` (the default) is supported.
