### PR TITLE
support weights(..., type = "working")

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,11 @@
   because currently only `"stage2"` (the default) is supported (reported in #26
   by Matthew Bhagat-Conway).
 
+* Now `weights(..., type = "working")` also works for `ivreg` objects. These
+  are simply the weights already available previously as
+  `weights(..., type = "variance")` as these are now used in computations of
+  `lm.influence()`, e.g., `dffits()`.
+
 
 # Version 0.6-5
 

--- a/R/ivregMethods.R
+++ b/R/ivregMethods.R
@@ -176,8 +176,8 @@ model.matrix.ivreg_projected <- function(object, ...) model.matrix.ivreg(object,
 #' for \code{residuals}, one of \code{"response"} (the default), \code{"projected"}, \code{"regressors"},
 #' \code{"working"}, \code{"deviance"}, \code{"pearson"}, or \code{"partial"}; 
 #' \code{type = "working"} and \code{"response"} are equivalent, as are 
-#' \code{type = "deviance"} and \code{"pearson"}; for \code{weights}, \code{"variance"} (the default)
-#' for invariance-variance weights (which is \code{NULL} for an unweighted fit) 
+#' \code{type = "deviance"} and \code{"pearson"}; for \code{weights}, \code{"working"} (or equivalently
+#' \code{"variance"}, the default) for invariance-variance weights (which is \code{NULL} for an unweighted fit) 
 #' or \code{"robustness"} for robustness weights (available for M or MM estimation).
 #' @param se.fit Compute standard errors of predicted values (default \code{FALSE}).
 #' @param interval Type of interval to compute for predicted values: \code{"none"} (the default),
@@ -437,7 +437,7 @@ qr.ivreg <- function(x, ...){
 
 #' @rdname ivregMethods
 #' @export
-weights.ivreg <- function(object, type=c("variance", "robustness"), ...){
-  type <- match.arg(type, c("variance", "robustness"))
-  if (type == "variance") object$weights else object$rweights
+weights.ivreg <- function(object, type = c("working", "variance", "robustness"), ...){
+  type <- match.arg(type, c("working", "variance", "robustness"))
+  if (type %in% c("working", "variance")) object$weights else object$rweights
 }

--- a/man/ivregMethods.Rd
+++ b/man/ivregMethods.Rd
@@ -76,7 +76,7 @@
 
 \method{qr}{ivreg}(x, ...)
 
-\method{weights}{ivreg}(object, type = c("variance", "robustness"), ...)
+\method{weights}{ivreg}(object, type = c("working", "variance", "robustness"), ...)
 }
 \arguments{
 \item{object, model, mod}{An object of class \code{"ivreg"}.}
@@ -99,8 +99,8 @@ predicted (i.e., fitted) values are computed for the data to which the model was
 for \code{residuals}, one of \code{"response"} (the default), \code{"projected"}, \code{"regressors"},
 \code{"working"}, \code{"deviance"}, \code{"pearson"}, or \code{"partial"}; 
 \code{type = "working"} and \code{"response"} are equivalent, as are 
-\code{type = "deviance"} and \code{"pearson"}; for \code{weights}, \code{"variance"} (the default)
-for invariance-variance weights (which is \code{NULL} for an unweighted fit) 
+\code{type = "deviance"} and \code{"pearson"}; for \code{weights}, \code{"working"} (or equivalently
+\code{"variance"}, the default) for invariance-variance weights (which is \code{NULL} for an unweighted fit) 
 or \code{"robustness"} for robustness weights (available for M or MM estimation).}
 
 \item{na.action}{\code{na} method to apply to predictor values for predictions; default is \code{\link{na.pass}}.}


### PR DESCRIPTION
Fixes #29 

Now the `weights(...)` method also supports `weights(..., type = "working")` which is equivalent to what was already previously called `type = "variance"`. The reason is that `weighted.residuals()` relies on this in recent versions of R which in turn is used in `lm.influence()`, e.g., `dffits()` etc.