### PR TITLE
fix structure() calls with deprecated .Names and .Dimnames

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ivreg
 Title: Instrumental-Variables Regression by '2SLS', '2SM', or '2SMM', with Diagnostics
-Version: 0.6-7
-Date: 2026-03-02
+Version: 0.6-8
+Date: 2026-07-11
 Authors@R: c(person(given = "John", family = "Fox", role = "aut", email = "jfox@mcmaster.ca", comment = c(ORCID = "0000-0002-1196-8012")),
              person(given = "Christian", family = "Kleiber", role = "aut", email = "Christian.Kleiber@unibas.ch", comment = c(ORCID = "0000-0002-6781-4733")),
              person(given = "Achim", family = "Zeileis", role = c("aut", "cre"), email = "Achim.Zeileis@R-project.org", comment = c(ORCID = "0000-0003-0918-3766")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# Version 0.6-8
+
+* Updated `structure()` calls to use `names = ...` instead of `.Names = ...` etc.
+
+
 # Version 0.6-7
 
 * New methods for `dffits()` generic in R-devel (to be 4.6.0) for `ivreg` and

--- a/R/ivreg.fit.R
+++ b/R/ivreg.fit.R
@@ -133,7 +133,7 @@ ivreg.fit <- function(x, y, z, weights, offset, method = c("OLS", "M", "MM"),
   ## infer endogenous variables in x and instruments in z
   rowAbsMaxs <- function(x, ...) apply(abs(as.matrix(x)), 1L, max, ...)
   colAbsMaxs <- function(x, ...) apply(abs(as.matrix(x)), 2L, max, ...)
-  exog <- structure(seq_along(colnames(x)), .Names = colnames(x))
+  exog <- structure(seq_along(colnames(x)), names = colnames(x))
   if(!is.null(auxreg)) {
     endo <- which(colAbsMaxs(auxreg$residuals) > sqrt(.Machine$double.eps))
     inst <- coef(auxreg)

--- a/R/ivregMethods.R
+++ b/R/ivregMethods.R
@@ -53,7 +53,7 @@ coef.ivreg <- function(object, component = c("stage2", "stage1"), complete = TRU
   } else {
   ## or: stage 1 with multiple endogenous variables
     cf <- object$coefficients1[, object$endogenous, drop = FALSE]
-    cf <- structure(as.vector(cf), .Names = as.vector(t(outer(colnames(cf), rownames(cf), paste, sep = ":"))))
+    cf <- structure(as.vector(cf), names = as.vector(t(outer(colnames(cf), rownames(cf), paste, sep = ":"))))
   }
   if (!complete) cf <- cf[!is.na(cf)]
   return(cf)
@@ -80,12 +80,12 @@ vcov.ivreg <- function(object, component = c("stage2", "stage1"), complete = TRU
     } else {
       sigma2 <- structure(
         crossprod(object$residuals1[, endo])/object$df.residual1,
-        .Dimnames = rep.int(list(colnames(object$residuals1)[endo]), 2L)
+        dimnames = rep.int(list(colnames(object$residuals1)[endo]), 2L)
       )
       vc <- kronecker(sigma2, ucov, make.dimnames = TRUE)
       ok <- structure(
         rep.int(ok, length(endo)),
-        .Names = as.vector(t(outer(colnames(cf)[endo], rownames(cf), paste, sep = ":"))))
+        names = as.vector(t(outer(colnames(cf)[endo], rownames(cf), paste, sep = ":"))))
     }
   }
   vc <- .vcov.aliased(!ok, vc, complete = complete)

--- a/R/summary.ivreg.R
+++ b/R/summary.ivreg.R
@@ -327,9 +327,9 @@ ivdiag <- function(obj, vcov. = NULL) {
     } else {
       if(NCOL(obj0$coefficients) > 1L) {
         cf0 <- structure(as.vector(obj0$coefficients),
-	  .Names = c(outer(rownames(obj0$coefficients), colnames(obj0$coefficients), paste, sep = ":")))
+	  names = c(outer(rownames(obj0$coefficients), colnames(obj0$coefficients), paste, sep = ":")))
         cf1 <- structure(as.vector(obj1$coefficients),
-	  .Names = c(outer(rownames(obj1$coefficients), colnames(obj1$coefficients), paste, sep = ":")))
+	  names = c(outer(rownames(obj1$coefficients), colnames(obj1$coefficients), paste, sep = ":")))
       } else {
         cf0 <- obj0$coefficients
         cf1 <- obj1$coefficients


### PR DESCRIPTION
Fixes #33 

To conform with the latest R development version `structure(..., names = ...)` is used instead of `structure(..., .Names = ...)` and analogously for `dimnames` instead of `.Dimnames`.